### PR TITLE
feat: facilitate role execution via Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,24 @@ tasks:
   setup:
     desc: "Install Ansible Galaxy roles and collections"
     cmds:
-      - mkdir ./ansible_galaxy || exit 0
+      - mkdir -p ./ansible_galaxy
       - ansible-galaxy role install -r requirements.yml -p ./ansible_galaxy/roles
       - ansible-galaxy collection install -r requirements.yml -p ./ansible_galaxy
+
+  # --- Execution ---
+  run:
+    desc: "Run the full playbook (requires sudo password)"
+    cmds:
+      - ansible-playbook -K local.yml
+
+  run:role:
+    desc: "Run a specific role. Usage: task run:role ROLE=<tag>"
+    cmds:
+      - ansible-playbook -K local.yml --tags {{.ROLE}}
+    requires:
+      vars: [ROLE]
+
+  list-tags:
+    desc: "List all available tags in the playbook"
+    cmds:
+      - ansible-playbook local.yml --list-tags

--- a/local.yml
+++ b/local.yml
@@ -10,9 +10,8 @@
     - role: geerlingguy.docker
       become: true
       vars:
-        docker_users:
-          "{{ ansible_user }}"
-      tags: 
+        docker_users: "{{ ansible_user }}"
+      tags:
         - docker
     - role: terminator
       tags:
@@ -30,6 +29,8 @@
         - vscode
     - role: anydesk
       become: true
+      tags:
+        - anydesk
     - role: slack
       become: true
       tags:


### PR DESCRIPTION
This PR addresses issue #7 by adding tasks to `Taskfile.yml` to facilitate running the Ansible playbook.

**Changes:**
- Added `run` task to `Taskfile.yml` to execute the full playbook.
- Added `run:role` task to `Taskfile.yml` to execute a specific role using tags.
- Added `list-tags` task to `Taskfile.yml` for convenience.
- Added `tags: [anydesk]` to the `anydesk` role in `local.yml` to enable targeted execution for this role.

**How to use:**
- Run full playbook: `task run`
- Run specific role: `task run:role ROLE=<tag>` (e.g., `task run:role ROLE=vscode`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces task-based execution for the Ansible playbook and tightens YAML config.
> 
> - Adds `run`, `run:role` (with `ROLE` var), and `list-tags` tasks in `Taskfile.yml`; ensures Galaxy dir via `mkdir -p`
> - Updates `local.yml`: fixes `docker_users` var formatting, explicitly tags `anydesk`, and normalizes tag blocks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac4e90631d27a5c37a1c0874fc60c834be228eed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->